### PR TITLE
CASMINST-5443: Authenticate to CSM's artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - CASMCMS-7970 - update dev.cray.com addresses.
+- Authenticate to CSM's artifactory
 
 ## [1.2.34] - undated

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN zypper in -y curl ca-certificates-mozilla python3-pip unzip
 COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 
-RUN curl -O https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_linux_amd64.zip && \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    curl -O https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_linux_amd64.zip && \
     unzip packer_1.6.0_linux_amd64.zip -d /usr/local && \
     pip3 install --upgrade pip && \
     pip3 install \


### PR DESCRIPTION
## Summary and Scope

Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.


## Issues and Related PRs


* Resolves CASMINST-5443

## Testing


### Tested on:

  * Build environment

### Test description:

It builds successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

