### PR TITLE
CASMINST-5443: Authenticate to CSM's artifactory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Cray Image Management Service image build environment Dockerfile
-# Copyright 2018, 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2018, 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,7 +29,8 @@ RUN zypper in -y curl ca-certificates-mozilla python3-pip unzip
 COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 
-RUN curl -O https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_linux_amd64.zip && \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    curl -O https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_linux_amd64.zip && \
     unzip packer_1.6.0_linux_amd64.zip -d /usr/local && \
     pip3 install --upgrade pip \
         --trusted-host arti.dev.cray.com \


### PR DESCRIPTION
## Summary and Scope

Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-5443

## Testing


### Tested on:

  * Tested by committing it to the build environment. There was not an artifactory available with the correct permissions to test against.

### Test description:

See above.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No.
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No.
- Was downgrade tested? If not, why? No.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations
Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

